### PR TITLE
Make tags, recipes, and ingredients clickable

### DIFF
--- a/app/assets/stylesheets/custom.scss
+++ b/app/assets/stylesheets/custom.scss
@@ -1,1 +1,32 @@
 @import "bootstrap";
+
+a.badge {
+    text-decoration: none;
+    display: inline-block;
+}
+
+a.badge::after {
+    content: '';
+    width: 0px;
+    height: 1px;
+    display: block;
+    transition: width 0.5s;
+
+    &.text-white {
+        background: var(--bs-white);
+    }
+
+    &.text-dark {
+        background: var(--bs-dark);
+    }
+}
+
+a.badge:hover::after {
+    width: 100%;
+}
+
+/* Class to escape stretched links */
+.clickable {
+    position: relative;
+    z-index: 2;
+}

--- a/app/controllers/recipes_controller.rb
+++ b/app/controllers/recipes_controller.rb
@@ -1,7 +1,7 @@
 class RecipesController < ApplicationController
     def index
-        @recipes = params[:search].present? ? Recipe.where('title LIKE ? OR description LIKE ? OR instructions LIKE ?', "%#{params[:search]}%", "%#{params[:search]}%", "%#{params[:search]}%").select(:id, :title, :description)
-            : Recipe.all.select(:id, :title, :description)
+        @pagy, @recipes = pagy(params[:search].present? ? Recipe.where('title LIKE ? OR description LIKE ? OR instructions LIKE ?', "%#{params[:search]}%", "%#{params[:search]}%", "%#{params[:search]}%").select(:id, :title, :description)
+            : Recipe.all.select(:id, :title, :description))
     end
 
     def show

--- a/app/controllers/tags_controller.rb
+++ b/app/controllers/tags_controller.rb
@@ -1,0 +1,6 @@
+class TagsController < ApplicationController
+    def show
+        @tag = Tag.find(params[:id])
+        @pagy, @ingredients = pagy(@tag.ingredients)
+    end
+end

--- a/app/models/ingredient.rb
+++ b/app/models/ingredient.rb
@@ -5,5 +5,7 @@ class Ingredient < ApplicationRecord
     has_many :recipe_ingredients, as: :mixable, dependent: :destroy, inverse_of: :mixable
     has_many :recipes, through: :recipe_ingredients, inverse_of: :mixables
 
+    has_one_attached :image
+
     validates :name, presence: true
 end

--- a/app/views/ingredients/_list.html.erb
+++ b/app/views/ingredients/_list.html.erb
@@ -1,0 +1,47 @@
+<div class="row row-cols-1 row-cols-sm-2 row-cols-md-3 row-cols-lg-4 row-cols-xl-5 g-3 mt-1">
+    <% @ingredients.each do |ingredient| %>
+        <div class="col">
+            <div class="card">
+                <% if ingredient.image.attached? %>
+                    <%= image_tag(ingredient.image, class: 'card-img-top') %>
+                <% end %>
+
+                <div class="card-body">
+                    <%# <img src="..." class="card-img-top" alt="..."> %>
+                    <h5 class="card-title"><%=ingredient.name%></h5>
+
+                    <% if ingredient.size.present? %>
+                        <h6 class="card-subtitle text-muted"><%= ingredient.size %></h6>
+                    <% end %>
+                </div>
+
+                <ul class="list-group list-group-flush">
+                    <% if ingredient.category.present? %>
+                        <li class="list-group-item"><strong>Type:</strong> <%= ingredient.category.titleize %></li>
+                    <% end %>
+                    <% if ingredient.abv? %>
+                        <li class="list-group-item"><strong>ABV:</strong> <%= "#{ingredient.abv}%" %></li>
+                    <% end %>
+                    <% if ingredient.vintage? %>
+                        <li class="list-group-item"><strong>Vintage:</strong> <%=ingredient.vintage%></li>
+                    <% end %>
+                </ul>
+
+                <div class="card-body">
+                    <%= form_tag(inventory_items_path) do -%>
+                        <%=hidden_field_tag "id", ingredient.id%>
+                        <%= link_to('View', ingredient, class: 'btn btn-secondary stretched-link') %>
+                        <%=submit_tag 'Add', class: 'btn btn-primary clickable'%>
+
+                    <%end-%>
+                </div>
+
+                <div class="card-footer small">
+                    <% ingredient.tags.each do |tag| %>
+                        <%= link_to(tag.name, tag, class: 'badge rounded-pill bg-dark text-white clickable') %>
+                    <% end %>
+                </div>
+            </div>
+        </div>
+    <% end %>
+</div>

--- a/app/views/ingredients/index.html.erb
+++ b/app/views/ingredients/index.html.erb
@@ -1,40 +1,6 @@
 <h1>All Ingredients</h1>
 
-<div class="row">
-    <div class="card-group">
-        <% @ingredients.each do |ingredient| %>
-            <ul>
-                <div class="card border-dark mb-3" style="max-width: 18rem;">
-                    <div class="card-body">
-                        <%# <img src="..." class="card-img-top" alt="..."> %>
-                        <h5 class="card-header"><%=ingredient.name%></h5>
-                        <div class="card-body">
-                            <ul class="list-group list-group-flush">
-                                <li class="list-group-item">Type: <%=ingredient.category%></li>
-                                <li class="list-group-item">ABV: <%= "#{ingredient.abv}%" %></li>
-                                <% if ingredient.vintage? %>
-                                    <li class="list-group-item">Vintage: <%=ingredient.vintage%></li>
-                                <% end %>
-                                <li class="list-group-item">Size: <%=ingredient.size%></li>
-                            </ul>
-                            <%= form_tag(inventory_items_path) do -%>
-                                <%=hidden_field_tag "id", ingredient.id%>
-                                <%=submit_tag 'Add', class: "btn btn-primary"%>
-
-                            <%end-%>
-                            
-                        </div>
-                        <div class="card-footer small">
-                            <% ingredient.tags.each do |tag| %>
-                                <span class="badge rounded-pill bg-dark"><%= tag.name %></span>
-                            <% end %>
-                        </div>
-                    </div>
-                </div>
-            </ul>
-        <% end %>
-    </div>
-</div>
+<%= render(partial: 'list') %>
 
 <%= render partial: 'shared/pagy_nav' %>
 

--- a/app/views/ingredients/show.html.erb
+++ b/app/views/ingredients/show.html.erb
@@ -1,3 +1,50 @@
-<h1>
-  <%= @ingredient.name %>
-</h1>
+<div class="card">
+  <% if @ingredient.image.attached? %>
+    <%= image_tag(@ingredient.image, class: 'card-img-top', style: 'max-height: 200px; object-fit: cover;') %>
+  <% end %>
+
+  <div class="card-body">
+    <h1 class="card-title"><%= @ingredient.name %></h1>
+
+    <% if @ingredient.size.present? %>
+      <h6 class="card-subtitle text-muted"><%= @ingredient.size %></h6>
+    <% end %>
+
+    <% if @ingredient.purchase_url? %>
+      <%= link_to('Purchase', @ingredient.purchase_url, class: 'btn btn-primary') %>
+    <% end %>
+  </div>
+  <ul class="list-group list-group-flush">
+    <% if @ingredient.category.present? %>
+      <li class="list-group-item"><strong>Type:</strong> <%= @ingredient.category.titleize %></li>
+    <% end %>
+    
+    <% if @ingredient.abv? %>
+      <li class="list-group-item"><strong>ABV:</strong> <%= @ingredient.abv %>%</li>
+    <% end %>
+
+    <% if @ingredient.vintage? %>
+      <li class="list-group-item"><strong>Vintage:</strong> <%= @ingredient.vintage %></li>
+    <% end %>
+
+    <% if @ingredient.metadata? %>
+      <% @ingredient.metadata.each do |key, value| %>
+        <li class="list-group-item">
+          <strong><%= key.titleize %>:</strong>
+          <% if key =~ /^kosher$|^ethical$|^organic$/i %>
+            <%= ActiveModel::Type::Boolean.new.cast(value) %>
+          <% elsif key =~ /price/i %>
+            $<%= value %>
+          <% else %>
+            <%= value %>
+          <% end %>
+        </li>
+      <% end %>
+    <% end %>
+  </ul>
+  <div class="card-footer small">
+      <% @ingredient.tags.each do |tag| %>
+        <%= link_to(tag.name, tag, class: 'badge rounded-pill bg-dark text-white') %>
+      <% end %>
+  </div>
+</div>

--- a/app/views/recipes/index.html.erb
+++ b/app/views/recipes/index.html.erb
@@ -20,7 +20,7 @@
                         <p class="card-text"><%= recipe.description.truncate(80, separator: /\s/) %></p>
                     <% end %>
 
-                    <%= link_to('View Recipe', recipe, class: 'btn btn-primary') %>
+                    <%= link_to('View Recipe', recipe, class: 'btn btn-primary stretched-link') %>
                 </div>
             </div>
         </div>

--- a/app/views/recipes/index.html.erb
+++ b/app/views/recipes/index.html.erb
@@ -26,3 +26,5 @@
         </div>
     <% end %>
 </div>
+
+<%= render(partial: 'shared/pagy_nav') %>

--- a/app/views/shared/_pagy_nav.html.erb
+++ b/app/views/shared/_pagy_nav.html.erb
@@ -1,4 +1,4 @@
-<div class="row">
+<div class="row mt-3">
     <div class="mx-auto w-auto">
         <%= pagy_bootstrap_nav(@pagy).html_safe %>
     </div>

--- a/app/views/shared/_recipe_ingredient.html.erb
+++ b/app/views/shared/_recipe_ingredient.html.erb
@@ -1,5 +1,5 @@
 <span>
-    <strong><%= recipe_ingredient.mixable.name.titleize %></strong>
+    <strong><%= link_to(recipe_ingredient.mixable.name.titleize, recipe_ingredient.mixable, class: 'link-dark') %></strong>
     <% if recipe_ingredient.note.present? %>
         <span>(<%= recipe_ingredient.note %>)</span>
     <% end %>

--- a/app/views/tags/show.html.erb
+++ b/app/views/tags/show.html.erb
@@ -1,0 +1,5 @@
+<h1><%= @tag.name.titleize %></h1>
+
+<%= render(partial: 'ingredients/list') %>
+
+<%= render(partial: 'shared/pagy_nav') %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -20,5 +20,6 @@ Rails.application.routes.draw do
   resources :ingredients, only: %i[index show]
   resources :recipes, only: %i[index show]
   resources :users
+  resources :tags, only: %i[show]
   
 end


### PR DESCRIPTION
## Trello Card

https://trello.com/c/ZaV2tdnY/49-make-recipe-ingredients-and-tags-clickable

## Description

This update makes several UI changes. It adds pages to view individual ingredients, adds pages to view individual tags, makes ingredients on recipe pages clickable, makes tags clickable, and makes cards on index pages clickable. It also cleans and reformats the index page for ingredients.

#### Clickable cards and tags

<img width="276" alt="Clickable cards with clickable tags" src="https://user-images.githubusercontent.com/32182454/227799619-c58d10ab-d5e1-4133-8dbe-92a2410a6463.png">

#### Page for individual tags

<img width="1430" alt="Page for the dark rum tag" src="https://user-images.githubusercontent.com/32182454/227799636-76cbcbc3-a275-47cc-ae76-e1a90e3a2fb2.png">

#### Clickable recipe ingredients

<img width="1417" alt="Recipe page with clickable ingredients" src="https://user-images.githubusercontent.com/32182454/227799655-dda93072-31d9-4f57-af7e-533b5465a964.png">

#### Cleaner and more informative ingredient page

<img width="1421" alt="New ingredient page" src="https://user-images.githubusercontent.com/32182454/227799672-71fa63d3-2802-475b-8a47-bd9dd6102117.png">

## Technical Changes

* Moved the main section of the ingredients `index` view into a partial and reused it in the new tags `show` view.
* Updated the partial to match the format of the recipe `index` view for cleaner, more consistent styling.
* Made cards on the partial and the recipe `index` view clickable via the bootstrap `stretched-link` class.
* Made tags at the bottoms of ingredient cards clickable (and added a cool underline animation when you hover over them!)
* Made ingredients on the recipe pages clickable.
* Updated the ingredient `show` view to be more informative.
* Added a small margin above the pagy nav.
* Paginated recipes.
