### PR TITLE
Add search bar to ingredient and tag pages

### DIFF
--- a/app/controllers/ingredients_controller.rb
+++ b/app/controllers/ingredients_controller.rb
@@ -4,9 +4,16 @@ class IngredientsController < ApplicationController
   end
 
   def index
-    @pagy, @ingredients = pagy(Ingredient.all)
+    @pagy, @ingredients = pagy(params[:search].present? ? search_ingredients : Ingredient.all)
   end
 
   def new
+  end
+
+  private
+
+  def search_ingredients
+    Ingredient.joins(:tags).distinct.where('ingredients.name LIKE ? OR tags.name LIKE ?',
+                                  "%#{params[:search]}%", "%#{params[:search]}%")
   end
 end

--- a/app/controllers/tags_controller.rb
+++ b/app/controllers/tags_controller.rb
@@ -1,6 +1,13 @@
 class TagsController < ApplicationController
     def show
         @tag = Tag.find(params[:id])
-        @pagy, @ingredients = pagy(@tag.ingredients)
+        @pagy, @ingredients = pagy(params[:search].present? ? search_tag : @tag.ingredients)
+    end
+
+    private
+
+    def search_tag
+        @tag.ingredients.joins(:tags).distinct.where('ingredients.name LIKE ? OR tags.name LIKE ?',
+                                  "%#{params[:search]}%", "%#{params[:search]}%")
     end
 end

--- a/app/views/ingredients/index.html.erb
+++ b/app/views/ingredients/index.html.erb
@@ -1,4 +1,6 @@
-<h1>All Ingredients</h1>
+<h1>Ingredients</h1>
+
+<%= render(partial: 'shared/basic_search') %>
 
 <%= render(partial: 'list') %>
 

--- a/app/views/recipes/index.html.erb
+++ b/app/views/recipes/index.html.erb
@@ -1,9 +1,6 @@
-<%= form_tag(recipes_path, method: :get) do %>
-    <div class="input-group">
-        <%= search_field_tag(:search, params[:search], placeholder: 'Search recipes', class: 'form-control') %>
-        <%= submit_tag('Search', class: 'btn btn-primary') %>
-    </div>
-<% end %>
+<h1>Recipes</h1>
+
+<%= render(partial: 'shared/basic_search') %>
 
 <div id="results" class="row row-cols-1 row-cols-sm-2 row-cols-md-3 row-cols-lg-4 row-cols-xl-5 g-3 mt-1">
     <% @recipes.each do |recipe| %>

--- a/app/views/shared/_basic_search.html.erb
+++ b/app/views/shared/_basic_search.html.erb
@@ -1,0 +1,6 @@
+<%= form_tag(request.path, method: :get) do %>
+    <div class="input-group">
+        <%= search_field_tag(:search, params[:search], placeholder: "Search #{controller_name.classify.downcase.pluralize}", class: 'form-control') %>
+        <%= submit_tag('Search', class: 'btn btn-primary') %>
+    </div>
+<% end %>

--- a/app/views/shared/_basic_search.html.erb
+++ b/app/views/shared/_basic_search.html.erb
@@ -1,6 +1,7 @@
 <%= form_tag(request.path, method: :get) do %>
     <div class="input-group">
-        <%= search_field_tag(:search, params[:search], placeholder: "Search #{controller_name.classify.downcase.pluralize}", class: 'form-control') %>
+        <%= search_field_tag(:search, params[:search], placeholder: defined?(:placeholder) ? placeholder
+                            : "Search #{controller_name.classify.downcase.pluralize}", class: 'form-control') %>
         <%= submit_tag('Search', class: 'btn btn-primary') %>
     </div>
 <% end %>

--- a/app/views/tags/show.html.erb
+++ b/app/views/tags/show.html.erb
@@ -1,5 +1,7 @@
 <h1><%= @tag.name.titleize %></h1>
 
+<%= render(partial: 'shared/basic_search', locals: { placeholder: "Search #{@tag.name} ingredients" }) %>
+
 <%= render(partial: 'ingredients/list') %>
 
 <%= render(partial: 'shared/pagy_nav') %>


### PR DESCRIPTION
## Trello Card

https://trello.com/c/z0MTTxam/52-make-basic-search-bar-for-ingredients

## Description

Added a basic search bar to both the ingredients index page and the tag ingredients page.

<img width="1439" alt="Search bar on the ingredients page" src="https://user-images.githubusercontent.com/32182454/227831471-a73e8bd5-c303-4859-89d8-ad34eded2244.png">

<img width="1424" alt="Search bar on the tag ingredients page" src="https://user-images.githubusercontent.com/32182454/227831510-bc1dbf1c-44f5-4303-b149-be0fd220cd49.png">

## Technical Changes

* Moved the recipe search bar into a partial.
* Used the search bar partial on the ingredients `index` page and the tag `show` page.
* Added logic to the `IngredientsController` and the `TagsController` for searching.
* Changed the header on the ingredients page from **All Ingredients** to just **Ingredients**.
* Added a header to the recipes `index` page.
