### PR TITLE
Fix search bar placeholder error

### DIFF
--- a/app/views/shared/_basic_search.html.erb
+++ b/app/views/shared/_basic_search.html.erb
@@ -1,7 +1,7 @@
 <%= form_tag(request.path, method: :get) do %>
     <div class="input-group">
-        <%= search_field_tag(:search, params[:search], placeholder: defined?(:placeholder) ? placeholder
-                            : "Search #{controller_name.classify.downcase.pluralize}", class: 'form-control') %>
+        <% placeholder ||= "Search #{controller_name.classify.downcase.pluralize}" %>
+        <%= search_field_tag(:search, params[:search], placeholder:, class: 'form-control') %>
         <%= submit_tag('Search', class: 'btn btn-primary') %>
     </div>
 <% end %>


### PR DESCRIPTION
## Trello Card

https://trello.com/c/buyrZxf5/57-fix-search-bar-placeholder-error

## Description

Addresses a bug where going to the ingredients page shows an error that `placeholder` is not defined.

## Technical Changes

* Created a default value for the placeholder variable
