### PR TITLE
Fix recipe ingredients/tags associations

### DIFF
--- a/app/models/ingredient.rb
+++ b/app/models/ingredient.rb
@@ -6,7 +6,7 @@ class Ingredient < ApplicationRecord
     has_many :users, through: :ingredient_items, inverse_of: :ingredients
 
     has_many :recipe_ingredients, as: :mixable, dependent: :destroy, inverse_of: :mixable
-    has_many :recipes, through: :recipe_ingredients, inverse_of: :mixables
+    has_many :recipes, through: :recipe_ingredients, inverse_of: :ingredients
 
     has_one_attached :image
 

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -5,7 +5,7 @@ class Tag < ApplicationRecord
     has_many :ingredients, through: :ingredient_tags, inverse_of: :tags
 
     has_many :recipe_ingredients, as: :mixable, dependent: :destroy, inverse_of: :mixable
-    has_many :recipes, through: :recipe_ingredients, inverse_of: :mixables
+    has_many :recipes, through: :recipe_ingredients, inverse_of: :ingredient_tags
 
     validates :name, presence: true, uniqueness: true
 


### PR DESCRIPTION
## Trello Card

https://trello.com/c/96qeJndE/62-fix-recipe-ingredients-tags-associations

## Description

No user-facing changes.

## Technical Changes

* Fixes the polymorphic `mixables` association in the `Recipe` model, splitting it into distinct `ingredients` (source type = `Ingredient`) and `ingredient_tags` (source type = `Tag`) associations.
* Creates a `Recipe#tags` method that returns an array of distinct names of tags and ingredient tags for the recipe.
* Creates a `Recipe#weighted_tags_histogram` method that returns a hash where the keys are names of tags and the values are the number of times the respective tag is associated with the recipe. Tags directly associated with a recipe (via the `ingredient_tags` association, as opposed to through an `Ingredient`) have 5x the weight.
