### PR TITLE
Adjust decision tree features

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -41,8 +41,6 @@ gem "font-awesome-sass", "~> 6.4.0"
 
 gem 'decisiontree'
 
-gem 'graphr'
-
 # Use Redis adapter to run Action Cable in production
 # gem "redis", "~> 4.0"
 
@@ -72,6 +70,8 @@ group :development, :test do
   gem "debug", platforms: %i[ mri mingw x64_mingw ]
   # Load environment variables from `.env`
   gem 'dotenv-rails'
+  # Use with decisiontree to see the structure
+  gem 'graphr'
 end
 
 group :development do

--- a/Gemfile
+++ b/Gemfile
@@ -41,6 +41,8 @@ gem "font-awesome-sass", "~> 6.4.0"
 
 gem 'decisiontree'
 
+gem 'graphr'
+
 # Use Redis adapter to run Action Cable in production
 # gem "redis", "~> 4.0"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -109,6 +109,7 @@ GEM
       sassc (~> 2.0)
     globalid (1.0.1)
       activesupport (>= 5.0)
+    graphr (0.2.1)
     i18n (1.12.0)
       concurrent-ruby (~> 1.0)
     importmap-rails (1.1.5)
@@ -255,6 +256,7 @@ DEPENDENCIES
   decisiontree
   dotenv-rails
   font-awesome-sass (~> 6.4.0)
+  graphr
   importmap-rails
   jbuilder
   jquery-rails

--- a/app/models/recipe.rb
+++ b/app/models/recipe.rb
@@ -29,6 +29,6 @@ class Recipe < ApplicationRecord
 
     def format_for_decision_tree(user)
         t = weighted_tags_histogram.sort_by { |_k, v| v }
-        [user.compare_to_liked_recipes(self), t[-1]&.at(0), t[-2]&.at(0), t[-3]&.at(0), t[2]&.at(0), t[1]&.at(0), t[0]&.at(0)]
+        [user.compare_to_saved_recipes(self), user.compare_to_saved_recipes(self, liked: false), t[-1]&.at(0), t[-2]&.at(0), t[-3]&.at(0), t[2]&.at(0), t[1]&.at(0), t[0]&.at(0)]
     end
 end

--- a/app/models/recipe.rb
+++ b/app/models/recipe.rb
@@ -28,7 +28,6 @@ class Recipe < ApplicationRecord
     end
 
     def format_for_decision_tree(user)
-        t = weighted_tags_histogram.sort_by { |_k, v| v }
-        [user.compare_to_saved_recipes(self), user.compare_to_saved_recipes(self, liked: false), t[-1]&.at(0), t[-2]&.at(0), t[-3]&.at(0), t[2]&.at(0), t[1]&.at(0), t[0]&.at(0)]
+        [user.compare_to_saved_recipes(self), user.compare_to_saved_recipes(self, liked: false)]
     end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -20,34 +20,34 @@ class User < ApplicationRecord
     BCrypt::Password.create(string, cost: cost)
   end
 
-  def top_tag_recipes
-      top_tag = u.saved_recipe_tags_histogram.max_by { |k, v| v }[0]
+  def top_tag_recipes(liked: true)
+      top_tag = u.saved_recipe_tags_histogram(liked:).max_by { |k, v| v }[0]
       Tag.find_by(name: top_tag).recipes.where.not(id: u.recipes.ids)
   end
 
   # https://en.wikipedia.org/wiki/S%C3%B8rensen%E2%80%93Dice_coefficient
-  def compare_to_liked_recipes(recipe)
+  def compare_to_saved_recipes(recipe, liked: true)
       t1 = recipe.tags
-      t2 = saved_recipe_tags
+      t2 = saved_recipe_tags(liked:)
       t3 = t1.intersection(t2)
 
       2 * t3.count.to_f / (t1.count + t2.count)
   end
 
-  def saved_recipe_tags
+  def saved_recipe_tags(liked: true)
       tags = []
 
-      recipes.each do |recipe|
+      recipes.joins(:user_recipes).where('user_recipes.liked' => liked).each do |recipe|
           tags.concat(recipe.tags)
       end
 
       tags.uniq
   end
 
-  def saved_recipe_tags_histogram
+  def saved_recipe_tags_histogram(liked: true)
       tags = {}
 
-      recipes.each do |recipe|
+      recipes.joins(:user_recipes).where('user_recipes.liked' => liked).each do |recipe|
           tags.merge!(recipe.weighted_tags_histogram) { |_k, v1, v2| v1 + v2 }
       end
 
@@ -63,15 +63,15 @@ class User < ApplicationRecord
   private
 
   def generate_decision_tree
-    labels = ['similarity', 'top_tag', 'second_tag', 'third_tag', 'bottom_tag3', 'bottom_tag2', 'bottom_tag']
+    labels = ['similarity_liked', 'similarity_disliked', 'top_tag', 'second_tag', 'third_tag', 'bottom_tag3', 'bottom_tag2', 'bottom_tag']
 
     training = user_recipes.map do |ur|
       recipe = ur.recipe
       tags = recipe.weighted_tags_histogram.sort_by { |_k, v| v }
-      [compare_to_liked_recipes(recipe), tags[-1]&.at(0), tags[-2]&.at(0), tags[-3]&.at(0), tags[2]&.at(0), tags[1]&.at(0), tags[0]&.at(0), ur.liked? ? 'recommended' : 'not recommended']
+      [compare_to_saved_recipes(recipe), compare_to_saved_recipes(recipe, liked: false), tags[-1]&.at(0), tags[-2]&.at(0), tags[-3]&.at(0), tags[2]&.at(0), tags[1]&.at(0), tags[0]&.at(0), ur.liked? ? 'recommended' : 'not recommended']
     end
 
-    tree = DecisionTree::ID3Tree.new(labels, training, 'not recommended', similarity: :continuous, top_tag: :discrete, second_tag: :discrete, third_tag: :discrete, bottom_tag3: :discrete, bottom_tag2: :discrete, bottom_tag: :discrete)
+    tree = DecisionTree::ID3Tree.new(labels, training, 'not recommended', similarity_liked: :continuous, similarity_disliked: :continuous, top_tag: :discrete, second_tag: :discrete, third_tag: :discrete, bottom_tag3: :discrete, bottom_tag2: :discrete, bottom_tag: :discrete)
     tree.train
 
     tree

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -37,7 +37,7 @@ class User < ApplicationRecord
   def saved_recipe_tags(liked: true)
       tags = []
 
-      recipes.joins(:user_recipes).where('user_recipes.liked' => liked).each do |recipe|
+      recipes.where('user_recipes.liked' => liked).each do |recipe|
           tags.concat(recipe.tags)
       end
 
@@ -47,7 +47,7 @@ class User < ApplicationRecord
   def saved_recipe_tags_histogram(liked: true)
       tags = {}
 
-      recipes.joins(:user_recipes).where('user_recipes.liked' => liked).each do |recipe|
+      recipes.where('user_recipes.liked' => liked).each do |recipe|
           tags.merge!(recipe.weighted_tags_histogram) { |_k, v1, v2| v1 + v2 }
       end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -63,15 +63,14 @@ class User < ApplicationRecord
   private
 
   def generate_decision_tree
-    labels = ['similarity_liked', 'similarity_disliked', 'top_tag', 'second_tag', 'third_tag', 'bottom_tag3', 'bottom_tag2', 'bottom_tag']
+    labels = ['similarity_liked', 'similarity_disliked']
 
     training = user_recipes.map do |ur|
       recipe = ur.recipe
-      tags = recipe.weighted_tags_histogram.sort_by { |_k, v| v }
-      [compare_to_saved_recipes(recipe), compare_to_saved_recipes(recipe, liked: false), tags[-1]&.at(0), tags[-2]&.at(0), tags[-3]&.at(0), tags[2]&.at(0), tags[1]&.at(0), tags[0]&.at(0), ur.liked? ? 'recommended' : 'not recommended']
+      [compare_to_saved_recipes(recipe), compare_to_saved_recipes(recipe, liked: false), ur.liked? ? 'recommended' : 'not recommended']
     end
 
-    tree = DecisionTree::ID3Tree.new(labels, training, 'not recommended', similarity_liked: :continuous, similarity_disliked: :continuous, top_tag: :discrete, second_tag: :discrete, third_tag: :discrete, bottom_tag3: :discrete, bottom_tag2: :discrete, bottom_tag: :discrete)
+    tree = DecisionTree::ID3Tree.new(labels, training, 'not recommended', similarity_liked: :continuous, similarity_disliked: :continuous)
     tree.train
 
     tree


### PR DESCRIPTION
## Trello Card

https://trello.com/c/7WoswcWk/65-specify-similarity-feature-for-decision-tree

## Description

No user-facing changes.

## Technical Changes

* Install the graphr gem in the development environment for debugging the decision tree.
* Splits the similarity feature for the decision tree into two separate features: similarity to liked recipes and similarity to disliked recipes.
* Removes tag features from the decision tree.
